### PR TITLE
Discarding the master/slave jargon

### DIFF
--- a/stand_alone_modbus_test/python_modbus_client/control_ctrl.py
+++ b/stand_alone_modbus_test/python_modbus_client/control_ctrl.py
@@ -76,8 +76,8 @@ class Sprinkler_Control():
      temp["RESTART_PROGRAM"]           = self.restart_program
      temp["NATIVE_SPRINKLER"]          = self.direct_valve_control       
      temp["CLEAN_FILTER"]              = self.clean_filter
-     temp["OPEN_MASTER_VALVE"]         = self.open_master_valve
-     temp["CLOSE_MASTER_VALVE"]        = self.close_master_valve
+     temp["OPEN_MASTER_VALVE"]         = self.open_main_valve
+     temp["CLOSE_MASTER_VALVE"]        = self.close_main_valve
      temp["RESET_SYSTEM"]              = self.reset_system
      temp["CHECK_OFF"]                 = self.check_off
      temp["SHUT_DOWN"]                 = self.shut_down
@@ -116,12 +116,12 @@ class Sprinkler_Control():
         self.store_event_queue( "check_off", { "action":"start" } )
         self.redis.set( "sprinkler_ctrl_mode","CHECK_OFF")
         self.io.disable_all_sprinklers()
-        self.io.turn_on_master_valves()
+        self.io.turn_on_main_valves()
         
         time.sleep(90)
         self.measure_flow_rate ( chainFlowHandle, chainObj, parameters,event )
         self.measure_flow_rate (  chainFlowHandle, chainObj, parameters,event )
-        self.close_master_valve( data_object, chainFlowHandle,chainObj, parameters,event )
+        self.close_main_valve( data_object, chainFlowHandle,chainObj, parameters,event )
         print "off flow rate ",int(self.redis.get( "global_flow_sensor" ))*self.flow_scale
         if int(self.redis.get( "global_flow_sensor" ))*self.flow_scale   > 2:
            self.redis.set("SHUT_DOWN",1)
@@ -139,14 +139,14 @@ class Sprinkler_Control():
         print "check_off start"
         self.redis.set( "sprinkler_ctrl_mode","CHECK_OFF")
         self.io.disable_all_sprinklers()
-        self.io.turn_on_master_valves()
+        self.io.turn_on_main_valves()
         time.sleep(90)
         self.measure_flow_rate ( chainFlowHandle, chainObj, parameters,event )
         print "made 1"
         time.sleep(60)
         print "made 2 "
         self.measure_flow_rate (  chainFlowHandle, chainObj, parameters,event )
-        self.close_master_valve( 2,chainFlowHandle,chainObj, parameters,event )
+        self.close_main_valve( 2,chainFlowHandle,chainObj, parameters,event )
         print "made 3"
         temp = int(self.redis.get( "global_flow_sensor" ))*self.flow_scale
         if temp   > 2:
@@ -165,8 +165,8 @@ class Sprinkler_Control():
   #"OFFLINE" 
   def offline_command( self, data_object, chainFlowHandle,chainObj, parameters,event ):
       self.redis.set( "sprinkler_ctrl_mode","OFFLINE")
-      self.close_master_valve( data_object, chainFlowHandle,chainObj, parameters,event )
-      chainFlowHandle.disable_chain_base( ["master_valve_timed_off","monitor_irrigation_cell","monitor_irrigation_job_queue"])
+      self.close_main_valve( data_object, chainFlowHandle,chainObj, parameters,event )
+      chainFlowHandle.disable_chain_base( ["main_valve_timed_off","monitor_irrigation_cell","monitor_irrigation_job_queue"])
       chainFlowHandle.enable_chain_base( ["monitor_irrigation_job_queue"])
       self.io.disable_all_sprinklers()
       self.clear_redis_sprinkler_data()
@@ -225,15 +225,15 @@ class Sprinkler_Control():
        schedule_name = "Clean_Filter"
        self.redis.set( "schedule_name",schedule_name)
        self.io.turn_off_cleaning_valves()
-       self.io.turn_on_master_valves()
+       self.io.turn_on_main_valves()
        time.sleep(90)  # let line charge up
-       self.io.turn_off_master_valves()
+       self.io.turn_off_main_valves()
        time.sleep(5)
        self.io.turn_on_cleaning_valves()
        time.sleep(20)
-       self.io.turn_on_master_valves()
+       self.io.turn_on_main_valves()
        time.sleep(10)
-       self.io.turn_off_master_valves()
+       self.io.turn_off_main_valves()
        self.io.turn_off_cleaning_valves()
        self.store_event_queue( "clean_filter", { "action":"stop" } )
        self.redis.set("schedule_name",temp)
@@ -246,15 +246,15 @@ class Sprinkler_Control():
        self.store_event_queue( "clean_filter", { "action":"start" } )
        self.redis.set( "schedule_name",schedule_name)
        self.io.turn_off_cleaning_valves()
-       self.io.turn_on_master_valves()
+       self.io.turn_on_main_valves()
        time.sleep(90)  # let line charge up
-       self.io.turn_off_master_valves()
+       self.io.turn_off_main_valves()
        time.sleep(5)
        self.io.turn_on_cleaning_valves()
        time.sleep(20)
-       self.io.turn_on_master_valves()
+       self.io.turn_on_main_valves()
        time.sleep(10)
-       self.io.turn_off_master_valves()
+       self.io.turn_off_main_valves()
        self.io.turn_off_cleaning_valves()
        self.store_event_queue( "clean_filter", { "action":"stop" } )
        self.redis.set("schedule_name",temp)
@@ -262,17 +262,17 @@ class Sprinkler_Control():
        self.redis.set("cleaning_sum",0)
   # tested  
   #"OPEN_MASTER_VALVE"
-  def open_master_valve( self, data_object, chainFlowHandle, chainObj, parameters, event ):
-      #print "made and open master valuve"
-      self.io.turn_on_master_valves()
-      chainFlowHandle.disable_chain_base([ "master_valve_timed_off"])
-      chainFlowHandle.enable_chain_base( ["master_valve_timed_off" ])
+  def open_main_valve( self, data_object, chainFlowHandle, chainObj, parameters, event ):
+      #print "made and open main valuve"
+      self.io.turn_on_main_valves()
+      chainFlowHandle.disable_chain_base([ "main_valve_timed_off"])
+      chainFlowHandle.enable_chain_base( ["main_valve_timed_off" ])
      
   # tested  
   #"CLOSE_MASTER_VALVE"  
-  def close_master_valve( self, data_object, chainFlowHandle, chainObj, parameters, event ):
-      chainFlowHandle.disable_chain_base( ["master_valve_timed_off"])
-      self.io.turn_off_master_valves()
+  def close_main_valve( self, data_object, chainFlowHandle, chainObj, parameters, event ):
+      chainFlowHandle.disable_chain_base( ["main_valve_timed_off"])
+      self.io.turn_off_main_valves()
       
     
  
@@ -988,9 +988,9 @@ class Valve_Control():
   def check_switches_set( self, chainFlowHandle, chainObj, parameters, event ):
       returnValue = False
       if  event['name'] == 'TIME_TICK':
-          temp = int(redis.get("master_valve_set_switch"))
+          temp = int(redis.get("main_valve_set_switch"))
           if temp != 0: 
-               redis.set("master_valve_set_switch",0)
+               redis.set("main_valve_set_switch",0)
                returnValue = True
           else:
                returnValue = False
@@ -1000,33 +1000,33 @@ class Valve_Control():
   def detect_switch_off( self, chainFlowHandle, chainObj, parameters, event ):
       returnValue = "CONTINUE"
       if  event['name'] == 'TIME_TICK' :
-          temp = int(redis.get("master_valve_reset_switch"))
+          temp = int(redis.get("main_valve_reset_switch"))
           if temp != 0: 
-             redis.set("master_valve_reset_switch",1)
-             chainFlowHandle.disable_chain_base( ["master_valve_timed_off"] )
+             redis.set("main_valve_reset_switch",1)
+             chainFlowHandle.disable_chain_base( ["main_valve_timed_off"] )
              returnValue = "HALT"
       return returnValue
   
   
   def turn_on( self, chainFlowHandle, chainObj, parameters, event ):
-           self.io.turn_on_master_valves()
+           self.io.turn_on_main_valves()
   
   def turn_off_if_no_in_queue( self, chainFlowHandle, chainObj, parameters, event ):
         length =   self.redis.llen( "IRRIGATION_CELL_QUEUE" )
         if length == 0 :
-          self.io.turn_off_master_valves()
+          self.io.turn_off_main_valves()
           self.io.turn_off_cleaning_valves()
   
   
   def verify_off_switch_not_set( self, chainFlowHandle, chainObj, parameters, event ):
       returnValue = True
       if  event['name'] == 'TIME_TICK' :
-             temp = int(redis.get("master_valve_reset_switch"))
+             temp = int(redis.get("main_valve_reset_switch"))
              if temp != 0: 
                 returnValue = False
                 length =   self.redis.llen( "IRRIGATION_CELL_QUEUE" )
                 if length == 0:
-                  self.io.turn_off_master_valves()
+                  self.io.turn_off_main_valves()
              else:
                returnValue = True
       return returnValue
@@ -1110,16 +1110,16 @@ class Remote_Io():
       temp["command"] = "turn_off_cleaning_valves"
       self.do_rpc( temp )
   #tested
-  def turn_on_master_valves( self ):
+  def turn_on_main_valves( self ):
       self.redis.set( "MASTER_VALVE_SETUP","ON")
       temp = {}
-      temp["command"] = "turn_on_master_valves"
+      temp["command"] = "turn_on_main_valves"
       self.do_rpc( temp )
   #tested
-  def turn_off_master_valves( self ):
+  def turn_off_main_valves( self ):
       self.redis.set( "MASTER_VALVE_SETUP","OFF")
       temp = {}
-      temp["command"] = "turn_off_master_valves"
+      temp["command"] = "turn_off_main_valves"
       self.do_rpc( temp )
   #tested
   def turn_on_io( self , io_setup ):
@@ -1168,7 +1168,7 @@ class Remote_Io():
     
   #tested
   def disable_all_sprinklers( self ):
-      self.turn_off_master_valves()
+      self.turn_off_main_valves()
       temp = {}
       temp["command"] = "disable_all_sprinklers"
       temp["time" ]  = 2000 # 20 second wait
@@ -1228,7 +1228,7 @@ if __name__ == "__main__":
    modbus_udp               = modbus_UDP.ModbusUDPClient("127.0.0.1")
    alarm_queue              = AlarmQueue( redis )
    watch_dog_control        = WatchDogControl( modbus_udp, alarm_queue, remote_devices,{"CLICK":plc_click} )
-   #irrigation_control       = IrrigationControl( modbus_udp, alarm_queue, remote_devices,master_valve_list,remote_io, {"CLICK":plc_click} )
+   #irrigation_control       = IrrigationControl( modbus_udp, alarm_queue, remote_devices,main_valve_list,remote_io, {"CLICK":plc_click} )
 
 
 
@@ -1240,7 +1240,7 @@ if __name__ == "__main__":
            self.modbus_udp                   = modbus_UDP.ModbusUDPClient("127.0.0.1")
            self.alarm_queue                  = AlarmQueue( self.redis )
            self.watch_dog_control            = WatchDogControl( modbus_udp, alarm_queue, remote_devices,{"CLICK":plc_click} )
-           #self.irrigation_io                = IrrigationControl( modbus_udp, alarm_queue, remote_devices,master_valve_list,remote_io, {"CLICK":plc_click} )
+           #self.irrigation_io                = IrrigationControl( modbus_udp, alarm_queue, remote_devices,main_valve_list,remote_io, {"CLICK":plc_click} )
            self.device_directory             = "WD_DIRECTORY"
            self.app_files                    = app_files
            self.system_files                 = system_files
@@ -1314,14 +1314,14 @@ if __name__ == "__main__":
    cf.insert_link( "link_1", "WaitTod", ["*",13,"*","*"] )
    cf.insert_link( "link_2", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.disable_all_sprinklers ] )
    cf.insert_link( "link_3", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_off_cleaning_valves ] )
-   cf.insert_link( "link_4", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_on_master_valves ] )
+   cf.insert_link( "link_4", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_on_main_valves ] )
    cf.insert_link( "link_5", "WaitTime", [100] )
-   cf.insert_link( "link_6", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_off_master_valves ] ) 
+   cf.insert_link( "link_6", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_off_main_valves ] ) 
    cf.insert_link( "link_7", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_on_cleaning_valves ] )   
    cf.insert_link( "link_8", "WaitTime", [40] )    
-   cf.insert_link( "link_9", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_on_master_valves ] )    
+   cf.insert_link( "link_9", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.turn_on_main_valves ] )    
    cf.insert_link( "link_10", "WaitTime", [20] )
-   cf.insert_link( "link_11", "One_Step",  [ ir_ctl.sprinkler_control.irrigation_io.turn_off_master_valves ] ) 
+   cf.insert_link( "link_11", "One_Step",  [ ir_ctl.sprinkler_control.irrigation_io.turn_off_main_valves ] ) 
    cf.insert_link( "link_12", "One_Step",  [ ir_ctl.sprinkler_control.irrigation_io.turn_off_cleaning_valves ] )
    cf.insert_link( "link_13", "One_Step", [ ir_ctl.sprinkler_control.irrigation_io.disable_all_sprinklers ] )
    cf.insert_link( "link_14", "WaitTod", ["*",14,"*","*" ] )
@@ -1355,7 +1355,7 @@ if __name__ == "__main__":
 
 
 
-   cf.define_chain("manual_master_valve_on",True)
+   cf.define_chain("manual_main_valve_on",True)
    cf.insert_link( "link_0",   "Log",["start"] )
    cf.insert_link( "link_1",    "Code", [ ir_ctl.valve_control.turn_off_if_no_in_queue ])
    cf.insert_link( "link_test", "Log",["valve off"] )
@@ -1370,7 +1370,7 @@ if __name__ == "__main__":
    cf.insert_link( "link_9",    "Reset",    [] )
   
   
-   cf.define_chain("master_valve_timed_off",False)
+   cf.define_chain("main_valve_timed_off",False)
    cf.insert_link( "link_1",  "Code", [  ir_ctl.valve_control.detect_switch_off ] )
    cf.insert_link( "link_4",    "One_Step", [ ir_ctl.valve_control.turn_on] )
    cf.insert_link( "link_2",  "Code", [ ir_ctl.valve_control.insure_that_valve_on ] )
@@ -1402,7 +1402,7 @@ if __name__ == "__main__":
 #ir_ctl.plc_watch_dog.modbus_read_wd_flag( None,None,None,None)
 #ir_ctl.plc_watch_dog.modbus_write_wd_flag( None,None,None,None)
 #ir_ctl.remote_io.construct_modbus_counters()
-#ir_ctl.remote_io.turn_off_master_valves()
+#ir_ctl.remote_io.turn_off_main_valves()
 #ir_ctl.remote_io.clean_filter()
 #ir_ctl.remote_io.disable_all_sprinklers()
 #io_setup = [["satellite_1", [12], 10]]

--- a/stand_alone_modbus_test/python_modbus_client/io_ctrl.py
+++ b/stand_alone_modbus_test/python_modbus_client/io_ctrl.py
@@ -128,11 +128,11 @@ class IO_mgr():
 
 
 class IrrigationIo():
-   def __init__(self, io_server, alarm_queue, remote_devices, master_valve_list,remote_io, plc_map ):
+   def __init__(self, io_server, alarm_queue, remote_devices, main_valve_list,remote_io, plc_map ):
        self.io_server           = io_server
        self.alarm_queue         = alarm_queue
        self.remote_devices      = remote_devices
-       self.master_valve_list   = master_valve_list
+       self.main_valve_list   = main_valve_list
        self.plc_map             = plc_map
        self.remote_io           = remote_io
 
@@ -145,30 +145,30 @@ class IrrigationIo():
               
   
 
-   def turn_on_master_valves( self,*arg ):
-       for master_valve in self.master_valve_list:
-           if master_valve["type"] == "CLICK":
-               address = remote_devices[ master_valve["remote"] ]["address"]
-               self.plc_map[master_valve["type"]].turn_on_master_valve( self.io_server,  address, master_valve )
+   def turn_on_main_valves( self,*arg ):
+       for main_valve in self.main_valve_list:
+           if main_valve["type"] == "CLICK":
+               address = remote_devices[ main_valve["remote"] ]["address"]
+               self.plc_map[main_valve["type"]].turn_on_main_valve( self.io_server,  address, main_valve )
             
     
-   def turn_off_master_valves( self,*arg ):
-       for master_valve in self.master_valve_list:
-           if master_valve["type"] == "CLICK":
-               address = remote_devices[ master_valve["remote"] ]["address"]
-               self.plc_map[master_valve["type"]].turn_off_master_valve( self.io_server,  address, master_valve )
+   def turn_off_main_valves( self,*arg ):
+       for main_valve in self.main_valve_list:
+           if main_valve["type"] == "CLICK":
+               address = remote_devices[ main_valve["remote"] ]["address"]
+               self.plc_map[main_valve["type"]].turn_off_main_valve( self.io_server,  address, main_valve )
 
    def turn_on_cleaning_valves( self,*arg ):
-       for master_valve in self.master_valve_list:
-           if master_valve["type"] == "CLICK":
-               address = remote_devices[ master_valve["remote"] ]["address"]
-               self.plc_map[master_valve["type"]].turn_on_cleaning_valve( self.io_server,  address, master_valve )
+       for main_valve in self.main_valve_list:
+           if main_valve["type"] == "CLICK":
+               address = remote_devices[ main_valve["remote"] ]["address"]
+               self.plc_map[main_valve["type"]].turn_on_cleaning_valve( self.io_server,  address, main_valve )
 
    def turn_off_cleaning_valves( self,*arg ):
-       for master_valve in self.master_valve_list:
-           if master_valve["type"] == "CLICK":
-               address = remote_devices[ master_valve["remote"] ]["address"]
-               self.plc_map[master_valve["type"]].turn_off_cleaning_valve( self.io_server,  address, master_valve )
+       for main_valve in self.main_valve_list:
+           if main_valve["type"] == "CLICK":
+               address = remote_devices[ main_valve["remote"] ]["address"]
+               self.plc_map[main_valve["type"]].turn_off_cleaning_valve( self.io_server,  address, main_valve )
 
 
  
@@ -196,7 +196,7 @@ class IrrigationIo():
 
    def turn_off_io( self , io_setup ):
       # io_setup is a list of dict { "remote":xx , "bits":[1,2,3,4]
-      self.turn_off_master_valves_server()
+      self.turn_off_main_valves_server()
       for i in io_setup:      
          remote        = i["remote"]
          remote_dev    = self.remote_devices[remote]
@@ -218,7 +218,7 @@ class IrrigationIo():
 
 
    def turn_on_io( self ,io_setup ):
-      self.turn_on_master_valves_server()
+      self.turn_on_main_valves_server()
       for i in io_setup:      
          remote        = i["remote"]
          remote_dev    = self.remote_devices[remote]
@@ -243,7 +243,7 @@ if __name__ == "__main__":
    modbus_udp               = modbus_UDP.ModbusUDPClient("127.0.0.1")
    alarm_queue              = AlarmQueue( redis )
    watch_dog_control        = WatchDogControl( modbus_udp, alarm_queue, remote_devices,  {"CLICK":plc_click} )
-   irrigation_control       = IrrigationIo( modbus_udp, alarm_queue, remote_devices,master_valve_list,irrigation_io, {"CLICK":plc_click} )
+   irrigation_control       = IrrigationIo( modbus_udp, alarm_queue, remote_devices,main_valve_list,irrigation_io, {"CLICK":plc_click} )
    io_mgr = IO_mgr( redis, modbus_udp, {"CLICK":plc_click}, remote_devices, gpio_input_devices, analog_devices, counter_devices )
    
    if watch_dog_control.modbus_check_mode_switches() == True:
@@ -260,12 +260,12 @@ if __name__ == "__main__":
    #print modbus_udp.read_bit(100,23)
    #print "disable_all_sprinkers",  irrigation_control.disable_all_sprinklers()
    #print modbus_udp.read_bit( 100, plc_click.click_bit_address["C1"])
-   #print "turn on master valve"
-   irrigation_control.turn_on_master_valves()
+   #print "turn on main valve"
+   irrigation_control.turn_on_main_valves()
    irrigation_control.turn_on_cleaning_valves()
    time.sleep(2)
    io_mgr.measure_analog()
-   #irrigation_control.turn_off_master_valves()
+   #irrigation_control.turn_off_main_valves()
    time.sleep(2)
    
    
@@ -275,16 +275,16 @@ if __name__ == "__main__":
 #   irrigation_control.load_duration_counters( 15 )
    
    io_mgr.clear_gpio_in()
-   print  io_mgr.measure_gpio_in_pin( "master_valve_set_switch" )
+   print  io_mgr.measure_gpio_in_pin( "main_valve_set_switch" )
    io_mgr.measure_gpio_in()
-   irrigation_control.turn_off_master_valves()
+   irrigation_control.turn_off_main_valves()
    irrigation_control.turn_off_cleaning_valves()
    time.sleep(2)
    print io_mgr.measure_analog_pin("coil_current" )
-   #irrigation_control.turn_on_master_valves()
+   #irrigation_control.turn_on_main_valves()
    #time.sleep(2)
    #io_mgr.measure_analog()
-   #irrigation_control.turn_off_master_valves()
+   #irrigation_control.turn_off_main_valves()
    #time.sleep(2)
    
 

--- a/stand_alone_modbus_test/python_modbus_client/irrigation_ctl.py
+++ b/stand_alone_modbus_test/python_modbus_client/irrigation_ctl.py
@@ -1,8 +1,8 @@
 class IrrigationControl():
-   def __init__(self,  irrigation_devices=None, master_valve_list=None, plc_map=None , redis=None ):
+   def __init__(self,  irrigation_devices=None, main_valve_list=None, plc_map=None , redis=None ):
        self.redis              = redis
        self.irrigation_devices = irrigation_devices
-       self.master_valve_list  = master_valve_list
+       self.main_valve_list  = main_valve_list
        self.plc_map            = plc_map
 
    def disable_all_sprinklers( self,*arg ):
@@ -15,31 +15,31 @@ class IrrigationControl():
               
   
 
-   def turn_on_master_valves( self,*arg ):
+   def turn_on_main_valves( self,*arg ):
        self.redis.hset("CONTROL_VARIABLES","MASTER_VALVE_SETUP","ON")
-       print "master on"
-       for redis_key, device in self.master_valve_list.items():
+       print "main on"
+       for redis_key, device in self.main_valve_list.items():
            if self.plc_map.has_key( device["type"] ):
                plc = self.plc_map[ device["type"] ]
                remote = device["remote"]
-               valve_list = [device["master_valve"]]
+               valve_list = [device["main_valve"]]
                if len( valve_list ) > 0:
                    plc.turn_on_valves( remote, valve_list)
             
-   def turn_off_master_valves( self,*arg ):
+   def turn_off_main_valves( self,*arg ):
        self.redis.hset("CONTROL_VARIABLES","MASTER_VALVE_SETUP","OFF")
-       print "master off"
-       for redis_key, device in self.master_valve_list.items():
+       print "main off"
+       for redis_key, device in self.main_valve_list.items():
            if self.plc_map.has_key( device["type"] ):
                plc = self.plc_map[ device["type"] ]
                remote = device["remote"]
-               valve_list = [device["master_valve"]]
+               valve_list = [device["main_valve"]]
                if len( valve_list ) > 0:
                    plc.turn_off_valves( remote, valve_list)
     
 
    def turn_on_cleaning_valves( self,*arg ):
-       for redis_key, device in self.master_valve_list.items():
+       for redis_key, device in self.main_valve_list.items():
            if self.plc_map.has_key( device["type"] ):
                plc = self.plc_map[ device["type"] ]
                remote = device["remote"]
@@ -48,7 +48,7 @@ class IrrigationControl():
                    plc.turn_on_valves(  remote, valve_list)
             
    def turn_off_cleaning_valves( self,*arg ):
-       for redis_key, device in self.master_valve_list.items():
+       for redis_key, device in self.main_valve_list.items():
            if self.plc_map.has_key( device["type"] ):
                plc = self.plc_map[ device["type"] ]
                remote = device["remote"]
@@ -77,7 +77,7 @@ class IrrigationControl():
 
    def turn_off_io( self , io_setup ):
        # io_setup is a list of dict { "remote":xx , "bits":[1,2,3,4]
-       self.turn_off_master_valves()
+       self.turn_off_main_valves()
        for i in io_setup:      
            remote        = i["remote"]
            bits          = i["bits"]  # list of outputs on remote to turn off
@@ -97,7 +97,7 @@ class IrrigationControl():
            if self.plc_map.has_key( dev_type ):
                plc = self.plc_map[ dev_type ]
                plc.turn_on_valves( remote, bits )
-       self.turn_on_master_valves()
+       self.turn_on_main_valves()
 
 
    def turn_on_valve( self ,io_setup ):

--- a/stand_alone_modbus_test/python_udp_serial_server/minimalmodbus.py
+++ b/stand_alone_modbus_test/python_udp_serial_server/minimalmodbus.py
@@ -89,16 +89,16 @@ MODE_ASCII = 'ascii'
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU or ASCII protocols (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU or ASCII protocols (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
         * mode (str): Mode selection. Can be MODE_RTU or MODE_ASCII.
 
     """
 
-    def __init__(self, port, slaveaddress, mode=MODE_RTU):
+    def __init__(self, port, subordinateaddress, mode=MODE_RTU):
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=STOPBITS, timeout=TIMEOUT)
         else:
@@ -122,11 +122,11 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.mode = mode
-        """Slave mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
+        """Subordinate mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
 
         New in version 0.6.
         """
@@ -147,7 +147,7 @@ class Instrument():
         self.handle_local_echo = False
         """Set to to :const:`True` if your RS-485 adaptor has local echo enabled. 
         Then the transmitted message will immeadiately appear at the receive line of the RS-485 adaptor.
-        MinimalModbus will then read and discard this data, before reading the data from the slave.
+        MinimalModbus will then read and discard this data, before reading the data from the subordinate.
         Defaults to :const:`False`.
 
         New in version 0.7.
@@ -171,15 +171,15 @@ class Instrument():
             )
 
     ######################################
-    ## Methods for talking to the slave ##
+    ## Methods for talking to the subordinate ##
     ######################################
 
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -194,10 +194,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -214,17 +214,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -239,7 +239,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -259,21 +259,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -297,17 +297,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -326,9 +326,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -336,8 +336,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -356,9 +356,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -369,12 +369,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -393,17 +393,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -420,13 +420,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -444,16 +444,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -473,12 +473,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -499,17 +499,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -546,11 +546,11 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770,
-        then use ``numberOfDecimals=1`` which will divide the received data from the slave by 10
+        If a value of 77.0 is stored internally in the subordinate register as 770,
+        then use ``numberOfDecimals=1`` which will divide the received data from the subordinate by 10
         before returning the value. Similarly ``numberOfDecimals=2`` will divide
         the received data by 100 before returning the value. Same functionality is also used
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -648,25 +648,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -688,37 +688,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -726,7 +726,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -754,15 +754,15 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -775,16 +775,16 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
 
         _checkFunctioncode(functioncode, None)
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
         # Build request
-        request = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        request = _embedPayload(self.address, self.mode, functioncode, payloadToSubordinate)
 
         # Calculate number of bytes to read
         number_of_bytes_to_read = DEFAULT_NUMBER_OF_BYTES_TO_READ
         if self.precalculate_read_size:
             try:
-                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSlave)
+                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSubordinate)
             except:
                 if self.debug:
                     template = 'MinimalModbus debug mode. Could not precalculate response size for Modbus {} mode. ' + \
@@ -795,19 +795,19 @@ class Instrument():
         response = self._communicate(request, number_of_bytes_to_read)
 
         # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, self.mode, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, request, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            request (str): The raw request that is to be sent to the slave.
+            request (str): The raw request that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -825,9 +825,9 @@ class Instrument():
 
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -936,35 +936,35 @@ class Instrument():
 ####################
 
 
-def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
-    """Build a request from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, mode, functioncode, payloaddata):
+    """Build a request from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) request string for sending to the slave (including CRC etc).
+        The built (raw) request string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
     The resulting request has the format:
-     * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
-     * ASCII Mode: header (:) + slaveaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
+     * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+     * ASCII Mode: header (:) + subordinateaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    The LRC or CRC is calculated from the byte string made up of slaveaddress + functioncode + payloaddata.
+    The LRC or CRC is calculated from the byte string made up of subordinateaddress + functioncode + payloaddata.
     The header, LRC/CRC, and footer are excluded from the calculation.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
 
     if mode == MODE_ASCII:
         request = _ASCII_HEADER + \
@@ -977,12 +977,12 @@ def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
     return request
 
 
-def _extractPayload(response, slaveaddress, mode, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, mode, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
         * functioncode (int): Used here for error checking only.
 
@@ -993,10 +993,10 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
     The received response should have the format:
-    * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
-    * ASCII Mode: header (:) + slaveaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
+    * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    * ASCII Mode: header (:) + subordinateaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    For development purposes, this function can also be used to extract the payload from the request sent TO the slave.
+    For development purposes, this function can also be used to extract the payload from the request sent TO the subordinate.
 
     """
     BYTEPOSITION_FOR_ASCII_HEADER          = 0  # Relative to plain response
@@ -1014,7 +1014,7 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
 
@@ -1074,18 +1074,18 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
                 response, plainresponse)
         raise ValueError(text)
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord(response[BYTEPOSITION_FOR_SLAVEADDRESS])
 
-    if responseaddress != slaveaddress:
-        raise ValueError('Wrong return slave address: {} instead of {}. The response is: {!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError('Wrong return subordinate address: {} instead of {}. The response is: {!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord(response[BYTEPOSITION_FOR_FUNCTIONCODE])
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {} instead of {}. The response is: {!r}'.format( \
@@ -1107,13 +1107,13 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 ############################################
 
 
-def _predictResponseSize(mode, functioncode, payloadToSlave):
-    """Calculate the number of bytes that should be received from the slave.
+def _predictResponseSize(mode, functioncode, payloadToSubordinate):
+    """Calculate the number of bytes that should be received from the subordinate.
 
     Args:
      * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
      * functioncode (int): Modbus function code.
-     * payloadToSlave (str): The raw request that is to be sent to the slave (not hex encoded string)
+     * payloadToSubordinate (str): The raw request that is to be sent to the subordinate (not hex encoded string)
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1138,14 +1138,14 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
     # Argument validity testing
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
-    _checkString(payloadToSlave, description='payload', minlength=MIN_PAYLOAD_LENGTH)
+    _checkString(payloadToSubordinate, description='payload', minlength=MIN_PAYLOAD_LENGTH)
 
     # Calculate payload size
     if functioncode in [5, 6, 15, 16]:
         response_payload_size = NUMBER_OF_PAYLOAD_BYTES_IN_WRITE_CONFIRMATION
 
     elif functioncode in [1, 2, 3, 4]:
-        given_size = _twoByteStringToNum(payloadToSlave[BYTERANGE_FOR_GIVEN_SIZE])
+        given_size = _twoByteStringToNum(payloadToSubordinate[BYTERANGE_FOR_GIVEN_SIZE])
         if functioncode == 1 or functioncode == 2:
             # Algorithm from MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b
             number_of_inputs = given_size
@@ -1159,7 +1159,7 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
 
     else:
         raise ValueError('Wrong functioncode: {}. The payload is: {!r}'.format( \
-            functioncode, payloadToSlave))
+            functioncode, payloadToSubordinate))
 
     # Calculate number of bytes to read
     if mode == MODE_ASCII:
@@ -1232,8 +1232,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1326,7 +1326,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1358,7 +1358,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1388,11 +1388,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
     encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1433,7 +1433,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1472,14 +1472,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1501,13 +1501,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1571,7 +1571,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -2065,11 +2065,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -2078,7 +2078,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):
@@ -2373,12 +2373,12 @@ def _interpretRawMessage(inputstr):
         Modbus bytestring decoder
         Input string (length 8 characters): '\n\x03\x10\x01\x00\x01\xd0q'
         Probably modbus RTU mode.
-        Slave address: 10 (dec). Function code: 3 (dec).
+        Subordinate address: 10 (dec). Function code: 3 (dec).
         Valid message. Extracted payload: '\x10\x01\x00\x01'
 
         Pos   Character Hex  Dec  Probable interpretation 
         -------------------------------------------------
-          0:  '\n'      0A    10  Slave address 
+          0:  '\n'      0A    10  Subordinate address 
           1:  '\x03'    03     3  Function code 
           2:  '\x10'    10    16  Payload    
           3:  '\x01'    01     1  Payload    
@@ -2400,26 +2400,26 @@ def _interpretRawMessage(inputstr):
         mode = MODE_RTU
     output += 'Probably Modbus {} mode.\n'.format(mode.upper())
 
-    # Extract slave address and function code
+    # Extract subordinate address and function code
     try:
         if mode == MODE_ASCII:
-            slaveaddress = int(inputstr[1:3])
+            subordinateaddress = int(inputstr[1:3])
             functioncode = int(inputstr[3:5])
         else:
-            slaveaddress = ord(inputstr[0])
+            subordinateaddress = ord(inputstr[0])
             functioncode = ord(inputstr[1])
-        output += 'Slave address: {} (dec). Function code: {} (dec).\n'.format(slaveaddress, functioncode)
+        output += 'Subordinate address: {} (dec). Function code: {} (dec).\n'.format(subordinateaddress, functioncode)
     except:
-        output += '\nCould not extract slave address and function code. \n\n'
+        output += '\nCould not extract subordinate address and function code. \n\n'
 
     # Check message validity
     try:
-        extractedpayload = _extractPayload(inputstr, slaveaddress, mode, functioncode)
+        extractedpayload = _extractPayload(inputstr, subordinateaddress, mode, functioncode)
         output += 'Valid message. Extracted payload: {!r}\n'.format(extractedpayload)
     except (ValueError, TypeError) as err:
         output += '\nThe message does not seem to be valid Modbus {}. Error message: \n{}. \n\n'.format(mode.upper(), err.message)
     except NameError as err:
-        output += '\nNo message validity checking. \n\n' # Slave address or function code not available
+        output += '\nNo message validity checking. \n\n' # Subordinate address or function code not available
 
     # Generate table describing the message
     if mode == MODE_RTU:
@@ -2427,7 +2427,7 @@ def _interpretRawMessage(inputstr):
         output += '------------------------------------------------- \n'
         for i, character in enumerate(inputstr):
             if i==0:
-                description = 'Slave address'
+                description = 'Subordinate address'
             elif i==1:
                 description = 'Function code'
             elif i==len(inputstr)-2:
@@ -2456,7 +2456,7 @@ def _interpretRawMessage(inputstr):
                 
             else:
                 if i == 1:
-                    description = 'Slave address'
+                    description = 'Subordinate address'
                 elif i == 3:
                     description = 'Function code'
                 elif i == len(inputstr)-4:

--- a/stand_alone_modbus_test/python_udp_serial_server/modbus_tcp_control.py
+++ b/stand_alone_modbus_test/python_udp_serial_server/modbus_tcp_control.py
@@ -68,8 +68,8 @@ class Modbus_TCP_Control:
 
 
    def ping_device( self,address ,register ):
-       slave_id = 1
-       payload     = struct.pack("<BBBBBB",slave_id,3,(register>>8)&255,register&255,0,1)  # read register 0 1 length
+       subordinate_id = 1
+       payload     = struct.pack("<BBBBBB",subordinate_id,3,(register>>8)&255,register&255,0,1)  # read register 0 1 length
        calculatedChecksum = self._calculateCrcString(payload)
        payload = payload+calculatedChecksum
      

--- a/stand_alone_modbus_test/python_udp_serial_server/myModbus.py
+++ b/stand_alone_modbus_test/python_udp_serial_server/myModbus.py
@@ -97,16 +97,16 @@ MODE_ASCII = 'ascii'
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
         * mode (str): Mode selection. Can be MODE_RTU or MODE_ASCII!
 
     """
 
-    def __init__(self, port, slaveaddress, mode=MODE_RTU):
+    def __init__(self, port, subordinateaddress, mode=MODE_RTU):
         """
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=STOPBITS, timeout=TIMEOUT)
@@ -135,11 +135,11 @@ class Instrument():
         #if self.serial.port is None: # not needed as serial port is automatically opened
         #        self.serial.open()
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.mode = mode
-        """Slave mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
+        """Subordinate mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
 
         New in version 0.6.
         """
@@ -175,15 +175,15 @@ class Instrument():
             )
 
     ######################################
-    ## Methods for talking to the slave ##
+    ## Methods for talking to the subordinate ##
     ######################################
 
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -198,10 +198,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -218,17 +218,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -243,7 +243,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -264,21 +264,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -302,17 +302,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -331,9 +331,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -341,8 +341,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -361,9 +361,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -374,12 +374,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -398,17 +398,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -425,13 +425,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -449,16 +449,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -478,12 +478,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -503,12 +503,12 @@ class Instrument():
             numberOfRegisters=numberOfRegisters, payloadformat='registers')
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -529,12 +529,12 @@ class Instrument():
 
 
     def read_eeprom_registers(self, registeraddress, numberOfRegisters, functioncode=30):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -565,12 +565,12 @@ class Instrument():
         return return_value
     
     def read_fifo(self, registeraddress, numberOfRegisters, functioncode=33):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -601,17 +601,17 @@ class Instrument():
         return return_value
     
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -632,17 +632,17 @@ class Instrument():
 
         
     def special_command(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -664,17 +664,17 @@ class Instrument():
 
 
     def write_eeprom_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -716,11 +716,11 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770,
+        If a value of 77.0 is stored internally in the subordinate register as 770,
         then use ``numberOfDecimals=1`` which will divide the received data by 10
         before returning the value. Similarly ``numberOfDecimals=2`` will divide
         the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -820,25 +820,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4,30,33]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -860,38 +860,38 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
         if functioncode in [33]:
-            return payloadFromSlave
+            return payloadFromSubordinate
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4,30]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16,40]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode in [16,31,40]:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -899,7 +899,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4,30]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -927,15 +927,15 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -948,16 +948,16 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
 
         _checkFunctioncode(functioncode, None)
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
         # Build message
-        message = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        message = _embedPayload(self.address, self.mode, functioncode, payloadToSubordinate)
 
         # Calculate number of bytes to read
         number_of_bytes_to_read = DEFAULT_NUMBER_OF_BYTES_TO_READ
         if self.precalculate_read_size:
             try:
-                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSlave)
+                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSubordinate)
             except:
                 if self.debug:
                     template = 'MinimalModbus debug mode. Could not precalculate response size for Modbus {} mode. ' + \
@@ -969,19 +969,19 @@ class Instrument():
         response = self._communicate(message, number_of_bytes_to_read)
 
         # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, self.mode, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, message, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -999,9 +999,9 @@ class Instrument():
 
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -1094,35 +1094,35 @@ class Instrument():
 ####################
 
 
-def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, mode, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
     The resulting message has the format:
-     * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
-     * ASCII Mode: header (:) + slaveaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
+     * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+     * ASCII Mode: header (:) + subordinateaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    The LRC or CRC is calculated from the byte string made up of slaveaddress + functioncode + payloaddata.
+    The LRC or CRC is calculated from the byte string made up of subordinateaddress + functioncode + payloaddata.
     The header, LRC/CRC, and footer are excluded from the calculation.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
 
     if mode == MODE_ASCII:
         message = _ASCII_HEADER + \
@@ -1135,12 +1135,12 @@ def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
     return message
 
 
-def _extractPayload(response, slaveaddress, mode, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, mode, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): Used here for error checking only.
 
@@ -1151,10 +1151,10 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
     The received response should have the format:
-        RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
-        ASCII Mode: header (:) + slaveaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
+        RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+        ASCII Mode: header (:) + subordinateaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    For development purposes, this function can also be used to extract the payload from the message sent TO the slave.
+    For development purposes, this function can also be used to extract the payload from the message sent TO the subordinate.
 
     """
     BYTEPOSITION_FOR_ASCII_HEADER          = 0  # Relative to plain response
@@ -1172,7 +1172,7 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
 
@@ -1232,18 +1232,18 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
                 response, plainresponse)
         raise ValueError(text)
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord(response[BYTEPOSITION_FOR_SLAVEADDRESS])
 
-    if responseaddress != slaveaddress:
-        raise ValueError('Wrong return slave address: {} instead of {}. The response is: {!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError('Wrong return subordinate address: {} instead of {}. The response is: {!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord(response[BYTEPOSITION_FOR_FUNCTIONCODE])
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {} instead of {}. The response is: {!r}'.format( \
@@ -1265,13 +1265,13 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 ############################################
 
 
-def _predictResponseSize(mode, functioncode, payloadToSlave):
-    """Calculate the number of bytes that should be received from the slave.
+def _predictResponseSize(mode, functioncode, payloadToSubordinate):
+    """Calculate the number of bytes that should be received from the subordinate.
 
     Args:
      * mode (str) :
      * functioncode (int):
-     * payloadToSlave (str): The raw message that is to be sent to the slave (not hex encoded string)
+     * payloadToSubordinate (str): The raw message that is to be sent to the subordinate (not hex encoded string)
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1296,14 +1296,14 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
     # Argument validity testing
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
-    _checkString(payloadToSlave, description='payload', minlength=MIN_PAYLOAD_LENGTH)
+    _checkString(payloadToSubordinate, description='payload', minlength=MIN_PAYLOAD_LENGTH)
 
     # Calculate payload size
     if functioncode in [5, 6, 15, 16]:
         response_payload_size = NUMBER_OF_PAYLOAD_BYTES_IN_WRITE_CONFIRMATION
 
     elif functioncode in [1, 2, 3, 4]:
-        given_size = _twoByteStringToNum(payloadToSlave[BYTERANGE_FOR_GIVEN_SIZE])
+        given_size = _twoByteStringToNum(payloadToSubordinate[BYTERANGE_FOR_GIVEN_SIZE])
         if functioncode == 1 or functioncode == 2:
             # Algorithm from MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b
             number_of_inputs = given_size
@@ -1317,7 +1317,7 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
 
     else:
         raise ValueError('Wrong functioncode: {}. The payload is: {!r}'.format( \
-            functioncode, payloadToSlave))
+            functioncode, payloadToSubordinate))
 
     # Calculate number of bytes to read
     if mode == MODE_ASCII:
@@ -1390,8 +1390,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1484,7 +1484,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1516,7 +1516,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1546,11 +1546,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1591,7 +1591,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1630,14 +1630,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1659,13 +1659,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1729,7 +1729,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -2212,11 +2212,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -2225,7 +2225,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/stand_alone_modbus_test/python_udp_serial_server/test/myModbus.py
+++ b/stand_alone_modbus_test/python_udp_serial_server/test/myModbus.py
@@ -94,16 +94,16 @@ MODE_ASCII = 'ascii'
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
         * mode (str): Mode selection. Can be MODE_RTU or MODE_ASCII!
 
     """
 
-    def __init__(self, port, slaveaddress, mode=MODE_RTU):
+    def __init__(self, port, subordinateaddress, mode=MODE_RTU):
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=STOPBITS, timeout=TIMEOUT)
         else:
@@ -127,11 +127,11 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.mode = mode
-        """Slave mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
+        """Subordinate mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
 
         New in version 0.6.
         """
@@ -167,15 +167,15 @@ class Instrument():
             )
 
     ######################################
-    ## Methods for talking to the slave ##
+    ## Methods for talking to the subordinate ##
     ######################################
 
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -190,10 +190,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -210,17 +210,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -235,7 +235,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -256,21 +256,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -294,17 +294,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -323,9 +323,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -333,8 +333,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -353,9 +353,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -366,12 +366,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -390,17 +390,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -417,13 +417,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -441,16 +441,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -470,12 +470,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -495,12 +495,12 @@ class Instrument():
             numberOfRegisters=numberOfRegisters, payloadformat='registers')
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -521,12 +521,12 @@ class Instrument():
 
 
     def read_eeprom_registers(self, registeraddress, numberOfRegisters, functioncode=30):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -557,12 +557,12 @@ class Instrument():
         return return_value
     
     def read_fifo(self, registeraddress, numberOfRegisters, functioncode=33):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -593,17 +593,17 @@ class Instrument():
         return return_value
     
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -624,17 +624,17 @@ class Instrument():
 
         
     def special_command(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -656,17 +656,17 @@ class Instrument():
 
 
     def write_eeprom_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -708,11 +708,11 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770,
+        If a value of 77.0 is stored internally in the subordinate register as 770,
         then use ``numberOfDecimals=1`` which will divide the received data by 10
         before returning the value. Similarly ``numberOfDecimals=2`` will divide
         the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -812,25 +812,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4,30,33]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -852,38 +852,38 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
         if functioncode in [33]:
-            return payloadFromSlave
+            return payloadFromSubordinate
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4,30]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16,40]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode in [16,31,40]:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -891,7 +891,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4,30]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -919,15 +919,15 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -940,16 +940,16 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
 
         _checkFunctioncode(functioncode, None)
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
         # Build message
-        message = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        message = _embedPayload(self.address, self.mode, functioncode, payloadToSubordinate)
 
         # Calculate number of bytes to read
         number_of_bytes_to_read = DEFAULT_NUMBER_OF_BYTES_TO_READ
         if self.precalculate_read_size:
             try:
-                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSlave)
+                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSubordinate)
             except:
                 if self.debug:
                     template = 'MinimalModbus debug mode. Could not precalculate response size for Modbus {} mode. ' + \
@@ -961,19 +961,19 @@ class Instrument():
         response = self._communicate(message, number_of_bytes_to_read)
 
         # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, self.mode, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, message, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -991,9 +991,9 @@ class Instrument():
 
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -1086,35 +1086,35 @@ class Instrument():
 ####################
 
 
-def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, mode, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
     The resulting message has the format:
-     * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
-     * ASCII Mode: header (:) + slaveaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
+     * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+     * ASCII Mode: header (:) + subordinateaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    The LRC or CRC is calculated from the byte string made up of slaveaddress + functioncode + payloaddata.
+    The LRC or CRC is calculated from the byte string made up of subordinateaddress + functioncode + payloaddata.
     The header, LRC/CRC, and footer are excluded from the calculation.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
 
     if mode == MODE_ASCII:
         message = _ASCII_HEADER + \
@@ -1127,12 +1127,12 @@ def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
     return message
 
 
-def _extractPayload(response, slaveaddress, mode, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, mode, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * mode (str): The modbus protcol mode (rtu or ascii)
         * functioncode (int): Used here for error checking only.
 
@@ -1143,10 +1143,10 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
     The received response should have the format:
-        RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
-        ASCII Mode: header (:) + slaveaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
+        RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+        ASCII Mode: header (:) + subordinateaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    For development purposes, this function can also be used to extract the payload from the message sent TO the slave.
+    For development purposes, this function can also be used to extract the payload from the message sent TO the subordinate.
 
     """
     BYTEPOSITION_FOR_ASCII_HEADER          = 0  # Relative to plain response
@@ -1164,7 +1164,7 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
 
@@ -1224,18 +1224,18 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
                 response, plainresponse)
         raise ValueError(text)
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord(response[BYTEPOSITION_FOR_SLAVEADDRESS])
 
-    if responseaddress != slaveaddress:
-        raise ValueError('Wrong return slave address: {} instead of {}. The response is: {!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError('Wrong return subordinate address: {} instead of {}. The response is: {!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord(response[BYTEPOSITION_FOR_FUNCTIONCODE])
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {} instead of {}. The response is: {!r}'.format( \
@@ -1257,13 +1257,13 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 ############################################
 
 
-def _predictResponseSize(mode, functioncode, payloadToSlave):
-    """Calculate the number of bytes that should be received from the slave.
+def _predictResponseSize(mode, functioncode, payloadToSubordinate):
+    """Calculate the number of bytes that should be received from the subordinate.
 
     Args:
      * mode (str) :
      * functioncode (int):
-     * payloadToSlave (str): The raw message that is to be sent to the slave (not hex encoded string)
+     * payloadToSubordinate (str): The raw message that is to be sent to the subordinate (not hex encoded string)
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1288,14 +1288,14 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
     # Argument validity testing
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
-    _checkString(payloadToSlave, description='payload', minlength=MIN_PAYLOAD_LENGTH)
+    _checkString(payloadToSubordinate, description='payload', minlength=MIN_PAYLOAD_LENGTH)
 
     # Calculate payload size
     if functioncode in [5, 6, 15, 16]:
         response_payload_size = NUMBER_OF_PAYLOAD_BYTES_IN_WRITE_CONFIRMATION
 
     elif functioncode in [1, 2, 3, 4]:
-        given_size = _twoByteStringToNum(payloadToSlave[BYTERANGE_FOR_GIVEN_SIZE])
+        given_size = _twoByteStringToNum(payloadToSubordinate[BYTERANGE_FOR_GIVEN_SIZE])
         if functioncode == 1 or functioncode == 2:
             # Algorithm from MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b
             number_of_inputs = given_size
@@ -1309,7 +1309,7 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
 
     else:
         raise ValueError('Wrong functioncode: {}. The payload is: {!r}'.format( \
-            functioncode, payloadToSlave))
+            functioncode, payloadToSubordinate))
 
     # Calculate number of bytes to read
     if mode == MODE_ASCII:
@@ -1382,8 +1382,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1476,7 +1476,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1508,7 +1508,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1538,11 +1538,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1583,7 +1583,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1622,14 +1622,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1651,13 +1651,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1721,7 +1721,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -2204,11 +2204,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -2217,7 +2217,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.